### PR TITLE
Fix color channel detachment

### DIFF
--- a/Shaders/quilt.shader
+++ b/Shaders/quilt.shader
@@ -45,9 +45,6 @@ uniform float slope;
 uniform float center;
 uniform float dpi;
 
-uniform float ri;
-uniform float bi;
-
 // IN OUT
 in vec2 fragTexCoord;
 out vec4 finalColor;
@@ -68,7 +65,6 @@ vec2 quilt_map(vec3 t, vec2 pos, float a) {
 
 void main (void) {
     vec4 holoPlayCalibration = vec4(dpi, pitch, slope, center);
-    vec2 holoPlayRB = vec2(ri, bi);
     
     vec3 color = vec3(0.0);
     vec2 uv = gl_FragCoord.xy;
@@ -81,9 +77,9 @@ void main (void) {
     float subp2 = subp * pitch;
     
     float a = (-st.x - st.y * tilt) * pitch - holoPlayCalibration.w;
-    color.r = texture(texture1, quilt_map(vec3(tile.xy, tile.x * tile.y), st, a-holoPlayRB.x*subp2)).r;
-    color.g = texture(texture1, quilt_map(vec3(tile.xy, tile.x * tile.y), st, a-subp2)).g;
-    color.b = texture(texture1, quilt_map(vec3(tile.xy, tile.x * tile.y), st, a-holoPlayRB.y*subp2)).b;
+    color.r = texture(texture1, quilt_map(vec3(tile.xy, tile.x * tile.y), st, a - 0.0 * subp2)).r;
+    color.g = texture(texture1, quilt_map(vec3(tile.xy, tile.x * tile.y), st, a - 1.0 * subp2)).g;
+    color.b = texture(texture1, quilt_map(vec3(tile.xy, tile.x * tile.y), st, a - 2.0 * subp2)).b;
     
     #if defined(HOLOPLAY_DEBUG_CENTER)
     // Mark center line only in central view

--- a/main.cpp
+++ b/main.cpp
@@ -51,10 +51,7 @@ int main()
     // LKG Config
     std::ifstream config_file("display.cfg");
     LKGConfig config(config_file);
-    
-    int ri = 0;
-    int bi = 2;
-    
+
     std::pair<float, float> angleDistance = scene->GetAngleDistance();
     std::pair<int, int> tiles = scene->GetTiles();
     std::pair<int, int> tileRes = scene->GetTileResolution();
@@ -69,10 +66,6 @@ int main()
     SetShaderValue(lkgFragment, centerLoc, &config.center, SHADER_UNIFORM_FLOAT);
     int dpiLoc = GetShaderLocation(lkgFragment, "dpi");
     SetShaderValue(lkgFragment, dpiLoc, &config.dpi, SHADER_UNIFORM_FLOAT);
-    int riLoc = GetShaderLocation(lkgFragment, "ri");
-    SetShaderValue(lkgFragment, riLoc, &ri, SHADER_UNIFORM_INT);
-    int biLoc = GetShaderLocation(lkgFragment, "bi");
-    SetShaderValue(lkgFragment, biLoc, &bi, SHADER_UNIFORM_INT);
     int tileLoc = GetShaderLocation(lkgFragment, "tile");
     float tile[2] = { tiles.first, tiles.second };
     SetShaderValue(lkgFragment, tileLoc, tile, SHADER_UNIFORM_VEC2);


### PR DESCRIPTION
This change fixes color channel detachment in the existing Quilt shader. After this change, the color changes are no longer detached.